### PR TITLE
disable download of zos-s390x packages

### DIFF
--- a/patches/DEPS.sed
+++ b/patches/DEPS.sed
@@ -1,9 +1,16 @@
-# Disable download of zos-s390x packages not present upstream; those that
-# are required (clang, ninja, gn) are already available on z/OS; others
-# such as reclient and luci-go, are currently not required on z/OS.
-#
 # Apply before running `gclient sync` while under the `v8` directory:
 # sed -i -f <path-to>/v8port/patches/DEPS.sed DEPS
 #
+# Disable download of zos-s390x packages not present upstream; those that
+# are required (clang, ninja, gn) are already available on z/OS; others
+# such as reclient and luci-go, are currently not required on z/OS:
+#
 s?host_cpu != "s390"?host_cpu != "s390" and host_os != "zos"?
 s?'condition': 'host_os != "aix"'?'condition': 'host_os != "aix" and host_os != "zos"'?
+#
+# Also force download of the depot_tools commit that includes the z/OS
+# port, so `gclient sync` works on the current v8port patches, until the
+# those patches are updated for a more recent V8 head commit than the
+# current (fce38915 from Nov 22 2023):
+#
+s?'38b8de056ebb9d0aa138f09907fa83c5b6107bb5'?'9d64acedead8bf69b1eee2645a18f8fd47a1100d'?

--- a/patches/DEPS.sed
+++ b/patches/DEPS.sed
@@ -1,0 +1,9 @@
+# Disable download of zos-s390x packages not present upstream; those that
+# are required (clang, ninja, gn) are already available on z/OS; others
+# such as reclient and luci-go, are currently not required on z/OS.
+#
+# Apply before running `gclient sync` while under the `v8` directory:
+# sed -i -f <path-to>/v8port/patches/DEPS.sed DEPS
+#
+s?host_cpu != "s390"?host_cpu != "s390" and host_os != "zos"?
+s?'condition': 'host_os != "aix"'?'condition': 'host_os != "aix" and host_os != "zos"'?

--- a/patches/build/git.20231122.968682938b.diff
+++ b/patches/build/git.20231122.968682938b.diff
@@ -1,7 +1,16 @@
 diff --git a/config/compiler/BUILD.gn b/config/compiler/BUILD.gn
-index de1cd6efc..341d72163 100644
+index de1cd6efc..fbb4b55b0 100644
 --- a/config/compiler/BUILD.gn
 +++ b/config/compiler/BUILD.gn
+@@ -1577,7 +1577,7 @@ config("compiler_deterministic") {
+ }
+ 
+ config("clang_revision") {
+-  if (is_clang && clang_base_path == default_clang_base_path) {
++  if (is_clang && clang_base_path == default_clang_base_path && current_os != "zos") {
+     update_args = [
+       "--print-revision",
+       "--verify-version=$clang_version",
 @@ -1882,6 +1882,13 @@ config("default_warnings") {
            # TODO(https://crbug.com/1490607): Fix and re-enable.
            "-Wno-thread-safety-reference-return",


### PR DESCRIPTION
- disable download of zos-s390x packages not present upstream; those that are required (clang, ninja, gn) are already available on z/OS; others such as reclient and luci-go, are currently not required on z/OS
- force download of the z/OS-supported depot_tools commit so `gclient sync` works on the current (fce38915 from Nov 22 2023) v8port patches, until those patches are updated with a more recent V8 head commit.
- bypass check of clang_revision since llvm-clang for zos-s390x is not in the upstream Google storage, and so is not downloaded

Run the following to update `v8/DEPS` (after `fetch v8` or `git pull`), before running `gclient sync` from under the `v8` directory:
```
$ sed -i -f <path-to>/v8port/patches/DEPS.sed DEPS
```
See https://issues.chromium.org/issues/323790693#comment12 - the last item "update the fetched v8/DEPS".

Example of the `and host_os != "zos"` changes to DEPS made by the above sed:
```
  'buildtools/linux64': {
    'packages': [
      {
        'package': 'gn/gn/linux-${{arch}}',
        'version': Var('gn_version'),
      }
    ],
    'dep_type': 'cipd',
    'condition': 'host_os == "linux" and host_cpu != "s390" and host_os != "zos" and host_cpu != "ppc"',
  },
...
  {
    # Note: On Win, this should run after win_toolchain, as it may use it.
    'name': 'clang',
    'pattern': '.',
    # clang not supported on aix
    'condition': 'host_os != "aix" and host_os != "zos"',
    'action': ['python3', 'tools/clang/scripts/update.py'],
  },
...
   'third_party/depot_tools':
-    Var('chromium_url') + '/chromium/tools/depot_tools.git' + '@' + '38b8de056ebb9d0aa138f09907fa83c5b6107bb5',
+    Var('chromium_url') + '/chromium/tools/depot_tools.git' + '@' + '9d64acedead8bf69b1eee2645a18f8fd47a1100d',
...
```
