### PR TITLE
Cleanup20250114

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,5 +1,10 @@
 name: Build and Test
 
+permissions:
+  contents: write
+  statuses: write
+  actions: read
+
 on:
   issue_comment:
     types:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,5 +1,10 @@
 name: 'Automatic version updates'
 
+permissions:
+  contents: write
+  statuses: write
+  actions: read
+
 on:
   schedule:
     # minute hour dom month dow (UTC)

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ log.STABLE/
 install/
 v8base/
 venv/
+.zoslib_hooks/
+out.log

--- a/buildenv
+++ b/buildenv
@@ -14,7 +14,7 @@ export ZOPEN_DEPS="depot_tools zoslib cmake make python gn ninja git comp_clang"
 export ZOPEN_RUNTIME_DEPS="zoslib python"
 # Nothing to configure or build:?
 export ZOPEN_CONFIGURE="skip"
-#export ZOPEN_MAKE="skip"
+export ZOPEN_CHECK="skip"
 export ZOPEN_MAKE="zopen_build"
 
 export ZOPEN_INSTALL="zopen_install"
@@ -73,37 +73,20 @@ zopen_build() {
   # update the compiler settings
   unset CFLAGS CXXFLAGS LDFLAGS
 
+  #
+  # do the exports for depot_tools
+  #
+  # Disable updating depot_tools
   export DEPOT_TOOLS_UPDATE=0
-  # do the export and the set
-  CUSTOM_CIPD_CLIENT=${DEPOT_TOOLS_HOME}/.cipd_client
-  export CUSTOM_CIPD_CLIENT=${DEPOT_TOOLS_HOME}/.cipd_client
-  export DEPOT_TOOLS_BOOTSTRAP_PYTHON3=0
-  export VPYTHON_BYPASS='manually managed python not supported by chrome operations'
-  # RESULT
-  # DEPOT_TOOLS_HOME : /z/jd895801/zopen/usr/local/zopen/depot_tools/depot_tools-main.20240726_201652.zos
-  # CUSTOM_CIPD_CLIENT : /z/jd895801/zopen/usr/local/zopen/depot_tools/depot_tools-main.20240726_201652.zos/.cipd_client
-  # VPYTHON_BYPASS : manually managed python not supported by chrome operations
-
-
-
-
-  # Disable updating depot_tools
-
   # Point to custom CIPD_CLIENT
-
-  # Disable updating depot_tools
-
-  # Disable commands:
-  # * ensure_bootstrap
-  # * update_depot_tools
-
-  # Disable vpython3 (use python directly); see depot_tools/vpython3.
-
   # Run the CIPD client that was built on z/OS; see depot_tools/cipd.
+  export CUSTOM_CIPD_CLIENT=${DEPOT_TOOLS_HOME}/.cipd_client
+  # ?
+  export DEPOT_TOOLS_BOOTSTRAP_PYTHON3=0
+  # Disable vpython3 (use python directly); see depot_tools/vpython3.
+  export VPYTHON_BYPASS='manually managed python not supported by chrome operations'
 
-  # Disable commands:
-  # * ensure_bootstrap
-  # * update_depot_tools
+
 
   # Create the virtual env in the v8port install dir
   echo "    Creating a python venv..."
@@ -118,15 +101,17 @@ zopen_build() {
   echo "updating the virtual env pip"
   python -m pip install -U pip
 
-  # Update the PYTHON_EXECUTABLE to fix six.moves problem
   echo "****************************************"
-  echo "PYTHON : $(type python)"
+  echo "SETUP VERIFICATION"
+  echo "PYTHON (type) : $(type python)"
+  echo "PYTHON (which) : $(which python)"
   echo "fetch : $(type -p fetch)"
   echo "PATH : ${PATH}"
   echo "DEPOT_TOOLS_UPDATE: ${DEPOT_TOOLS_UPDATE}"
   echo "DEPOT_TOOLS_HOME : ${DEPOT_TOOLS_HOME}"
   echo "CUSTOM_CIPD_CLIENT : ${CUSTOM_CIPD_CLIENT}"
   echo "VPYTHON_BYPASS : ${VPYTHON_BYPASS}"
+  echo "AWS checks"
   echo "env | grep -E '(DEPOT|CUSTOM)' : `env | grep -E '(DEPOT|CUSTOM)'`"
   echo "env | grep -E '(AWS)' : `env | grep -E '(AWS)'`"
   echo "****************************************"
@@ -147,10 +132,6 @@ zopen_build() {
   # change into v8base
   cd v8base
   # fetch
-  echo "**************"
-  echo "env | grep -E '(AWS)' : `env | grep -E '(AWS)'`"
-  echo "fetch v8..."
-  echo "**************"
   fetch v8
 
   # At this point, fetch is using depot_tools from third party
@@ -161,9 +142,6 @@ zopen_build() {
   #JFD EARLY EXIT
   #echo "JFD EARLY EXIT"
   #exit
-  echo "JFD FETCH COMPLETE ***********" 
-  echo "JFD FETCH COMPLETE ***********" 
-  echo "JFD FETCH COMPLETE ***********" 
   echo "JFD FETCH COMPLETE ***********" 
   echo "JFD FETCH COMPLETE ***********" 
   echo "JFD FETCH COMPLETE ***********" 
@@ -195,9 +173,6 @@ zopen_build() {
   #
   # apply patches
   #
-  echo "JFD ABOUT TO APPLY PATCHES ***********" 
-  echo "JFD ABOUT TO APPLY PATCHES ***********" 
-  echo "JFD ABOUT TO APPLY PATCHES ***********" 
   echo "JFD ABOUT TO APPLY PATCHES ***********" 
   echo "JFD ABOUT TO APPLY PATCHES ***********" 
   echo "JFD ABOUT TO APPLY PATCHES ***********" 
@@ -276,9 +251,6 @@ zopen_build() {
   echo "JFD APPLY PATCHES COMPLETE ***********" 
   echo "JFD APPLY PATCHES COMPLETE ***********" 
   echo "JFD APPLY PATCHES COMPLETE ***********" 
-  echo "JFD APPLY PATCHES COMPLETE ***********" 
-  echo "JFD APPLY PATCHES COMPLETE ***********" 
-  echo "JFD APPLY PATCHES COMPLETE ***********" 
 
 
   #
@@ -294,9 +266,6 @@ zopen_build() {
   export PATH="${PWD}:${ZOPEN_ROOT}/v8base/v8/buildtools/zos:$PATH" # for the 'ar' wrapper
   echo "ZOPEN_ROOT : ${ZOPEN_ROOT}"
   echo "PATH : ${PATH}"
-  #JFD EARLY EXIT
-  #echo "JFD EARLY EXIT"
-  #exit
 
 
 
@@ -384,5 +353,6 @@ zopen_append_to_setup()
   # At this time, ZOPEN_INSTAL_DIR is:
   # ${HOME}/zopen/usr/local/zopen/v8/v8-DEV
 
-  echo "echo \"append_to_setup()\""
+  # Do we want comments in the log?  Is this what this does?
+  echo "echo \"### append_to_setup() ### \""
 }

--- a/buildenv
+++ b/buildenv
@@ -262,9 +262,9 @@ zopen_build() {
   echo "Apply pax files to buildtools complete"
   echo "Apply pax files to buildtools complete"
 
-  echo "** APPLY PATCHES, PAX and OVERLAYS COMPLETE ***********" 
-  echo "** APPLY PATCHES, PAX and OVERLAYS COMPLETE ***********" 
-  echo "** APPLY PATCHES, PAX and OVERLAYS COMPLETE ***********" 
+  echo "JFD APPLY PATCHES COMPLETE ***********" 
+  echo "JFD APPLY PATCHES COMPLETE ***********" 
+  echo "JFD APPLY PATCHES COMPLETE ***********" 
 
 
   #

--- a/buildenv
+++ b/buildenv
@@ -9,9 +9,9 @@
 # Use zopen build -vv to see if the dependencies are being processed
 export ZOPEN_TYPE="BARE"
 export ZOPEN_NAME="v8"
-export ZOPEN_DEPS="depot_tools zoslib cmake make python gn ninja git comp_clang bash"
+export ZOPEN_DEPS="depot_tools zoslib cmake make check_python gn ninja git check_clang"
 
-export ZOPEN_RUNTIME_DEPS="zoslib python"
+export ZOPEN_RUNTIME_DEPS="zoslib check_python"
 # Nothing to configure or build:?
 export ZOPEN_CONFIGURE="skip"
 export ZOPEN_CHECK="skip"

--- a/buildenv
+++ b/buildenv
@@ -24,7 +24,7 @@ export ZOPEN_CATEGORIES="development language core"
 # User Tunable Paramters
 # Uncomment the following line to build d8 so that it uses a dynamic 
 # library rather than a static build:
-COMPONENT_BUILD="is_component_build=true"
+#COMPONENT_BUILD="is_component_build=true"
 [ -z "${COMPONENT_BUILD}" ] && COMPONENT_BUILD=""
 
 zopen_check_results()
@@ -68,7 +68,23 @@ zopen_build() {
   # enable tracing.
   #set -x
 
+  # works
   export PATH="${HOME}/zopen/usr/local/bin:${DEPOT_TOOLS_HOME}:${GN_HOME}:$PATH"
+  # will this work?
+  # export PATH="${DEPOT_TOOLS_HOME}:${GN_HOME}:$PATH"
+  # No.  It fails with:
+  # Generate ninja files using gn...
+  # Traceback (most recent call last):
+  #   File "/z/jd895801/zopen/usr/local/zopen/depot_tools/depot_tools-main/gn.py", line 99, in <module>
+  #     sys.exit(main(sys.argv))
+  #              ^^^^^^^^^^^^^^
+  #   File "/z/jd895801/zopen/usr/local/zopen/depot_tools/depot_tools-main/gn.py", line 73, in main
+  #     bin_path = gclient_paths.GetBuildtoolsPlatformBinaryPath()
+  #                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  #   File "/z/jd895801/zopen/usr/local/zopen/depot_tools/depot_tools-main/gclient_paths.py", line 147, in GetBuildtoolsPlatformBinaryPath
+  #     raise gclient_utils.Error('Unknown platform: ' + sys.platform)
+  # gclient_utils.Error: Unknown platform: zos
+
 
   # update the compiler settings
   unset CFLAGS CXXFLAGS LDFLAGS
@@ -272,18 +288,17 @@ zopen_build() {
   #
   echo "Generate ninja files using gn..."
   gn -v gen out/zos_s390x.release --args="is_debug=false treat_warnings_as_errors=false ${COMPONENT_BUILD}"
-  # Why was this done later?  Should we not do it now once the build output dir is there 
-  # and when the build happens?
-  # This is required when the built binaries (e.g. mksnapshot) and tests are run
+
+  # This is required when the built binaries (e.g. mksnapshot) and tests are run.
+  # Do this now, before tests are started so that when doing a component build
+  # it can find the .so's during testing.
   export LIBPATH=${ZOPEN_ROOT}/out/zos_s390x.release:$LIBPATH
+
   echo "Perform build using ninja..."
   V=1 ninja -v -j ${ZOPEN_NUM_JOBS} -C out/zos_s390x.release/
 
   # on exit return to the top level of the git repo
   cd ${ZOPEN_ROOT}
-
-  # This is required when the built binaries (e.g. mksnapshot) and tests are run
-  export LIBPATH=${ZOPEN_ROOT}/out/zos_s390x.release:$LIBPATH
 
   # disable tracing
   #set +x

--- a/buildenv
+++ b/buildenv
@@ -9,7 +9,7 @@
 # Use zopen build -vv to see if the dependencies are being processed
 export ZOPEN_TYPE="BARE"
 export ZOPEN_NAME="v8"
-export ZOPEN_DEPS="depot_tools zoslib cmake make check_python gn ninja git check_clang"
+export ZOPEN_DEPS="depot_tools zoslib cmake make check_python gn ninja git check_clang bas bash"
 
 export ZOPEN_RUNTIME_DEPS="zoslib check_python"
 # Nothing to configure or build:?

--- a/buildenv
+++ b/buildenv
@@ -24,7 +24,7 @@ export ZOPEN_CATEGORIES="development language core"
 # User Tunable Paramters
 # Uncomment the following line to build d8 so that it uses a dynamic 
 # library rather than a static build:
-#COMPONENT_BUILD="is_component_build=true"
+COMPONENT_BUILD="is_component_build=true"
 [ -z "${COMPONENT_BUILD}" ] && COMPONENT_BUILD=""
 
 zopen_check_results()
@@ -292,7 +292,8 @@ zopen_build() {
   # This is required when the built binaries (e.g. mksnapshot) and tests are run.
   # Do this now, before tests are started so that when doing a component build
   # it can find the .so's during testing.
-  export LIBPATH=${ZOPEN_ROOT}/out/zos_s390x.release:$LIBPATH
+  export LIBPATH=`pwd`/out/zos_s390x.release:$LIBPATH
+  echo "LIBPATH : ${LIBPATH}"
 
   echo "Perform build using ninja..."
   V=1 ninja -v -j ${ZOPEN_NUM_JOBS} -C out/zos_s390x.release/
@@ -313,6 +314,15 @@ zopen_install() {
 
   mkdir -p ${ZOPEN_INSTALL_DIR}
   cp -r * ${ZOPEN_INSTALL_DIR} # modify to copy the relevant scripts
+  # This is required for using the post install executables and libs
+  # when doing a component build.  If its not done here it should be
+  # specified as part of the env setup.
+  # TODO: JFD
+  # 1. Make mod to a check to see if build completed befor installing
+  # 2. Add this export to LIBPATH as part of install.
+  # 3. Only modify the LIBPATH if its a component build.
+  echo "Modify ENV as part of the post install setup for component build"
+  echo "export LIBPATH=${ZOPEN_ROOT}/out/zos_s390x.release:$LIBPATH"
 }
 
 #

--- a/buildenv
+++ b/buildenv
@@ -24,7 +24,7 @@ export ZOPEN_CATEGORIES="development language core"
 # User Tunable Paramters
 # Uncomment the following line to build d8 so that it uses a dynamic 
 # library rather than a static build:
-#COMPONENT_BUILD="is_component_build=true"
+COMPONENT_BUILD="is_component_build=true"
 [ -z "${COMPONENT_BUILD}" ] && COMPONENT_BUILD=""
 
 zopen_check_results()
@@ -120,9 +120,6 @@ zopen_build() {
   echo "Installing reqired package in venv"  
   pip install -r requirements.txt
 
-  # Try this to fix six.moves
-  pip install --upgrade six
-
   echo "Invoking gclient metrics --opt-out"
   # Comment out this line if you wish to participate.
   gclient metrics --opt-out
@@ -173,14 +170,15 @@ zopen_build() {
   #
   # apply patches
   #
-  echo "JFD ABOUT TO APPLY PATCHES ***********" 
-  echo "JFD ABOUT TO APPLY PATCHES ***********" 
-  echo "JFD ABOUT TO APPLY PATCHES ***********" 
+  echo "** gclient sync complete.  About to git stash. ***" 
   git stash
 
-  echo "Apply patches for overall repo"
-  echo "Apply patches for overall repo"
-  echo "Apply patches for overall repo"
+  echo "** APPLY PATCHES, PAX and OVERLAYS BEGIN ***********" 
+  echo "** APPLY PATCHES, PAX and OVERLAYS BEGIN ***********" 
+  echo "** APPLY PATCHES, PAX and OVERLAYS BEGIN ***********" 
+  echo "** APPLY PATCHES BEGIN ***********" 
+  echo "** APPLY PATCHES BEGIN ***********" 
+  echo "** APPLY PATCHES BEGIN ***********" 
   cd ${ZOPEN_ROOT}/v8base/v8
   echo "  -- compbuild"
   git apply ${ZOPEN_ROOT}/patches/git.v8.compbuild.diff
@@ -248,9 +246,9 @@ zopen_build() {
   echo "Apply pax files to buildtools complete"
   echo "Apply pax files to buildtools complete"
 
-  echo "JFD APPLY PATCHES COMPLETE ***********" 
-  echo "JFD APPLY PATCHES COMPLETE ***********" 
-  echo "JFD APPLY PATCHES COMPLETE ***********" 
+  echo "** APPLY PATCHES, PAX and OVERLAYS COMPLETE ***********" 
+  echo "** APPLY PATCHES, PAX and OVERLAYS COMPLETE ***********" 
+  echo "** APPLY PATCHES, PAX and OVERLAYS COMPLETE ***********" 
 
 
   #

--- a/buildenv
+++ b/buildenv
@@ -68,7 +68,7 @@ zopen_build() {
   # enable tracing.
   #set -x
 
-  export PATH="${DEPOT_TOOLS_HOME}:${GN_HOME}:$PATH"
+  export PATH="${HOME}/zopen/usr/local/bin:${DEPOT_TOOLS_HOME}:${GN_HOME}:$PATH"
 
   # update the compiler settings
   unset CFLAGS CXXFLAGS LDFLAGS
@@ -128,6 +128,7 @@ zopen_build() {
   echo "CUSTOM_CIPD_CLIENT : ${CUSTOM_CIPD_CLIENT}"
   echo "VPYTHON_BYPASS : ${VPYTHON_BYPASS}"
   echo "env | grep -E '(DEPOT|CUSTOM)' : `env | grep -E '(DEPOT|CUSTOM)'`"
+  echo "env | grep -E '(AWS)' : `env | grep -E '(AWS)'`"
   echo "****************************************"
 
   # Install the necessary requirements
@@ -146,7 +147,10 @@ zopen_build() {
   # change into v8base
   cd v8base
   # fetch
+  echo "**************"
+  echo "env | grep -E '(AWS)' : `env | grep -E '(AWS)'`"
   echo "fetch v8..."
+  echo "**************"
   fetch v8
 
   # At this point, fetch is using depot_tools from third party
@@ -157,6 +161,12 @@ zopen_build() {
   #JFD EARLY EXIT
   #echo "JFD EARLY EXIT"
   #exit
+  echo "JFD FETCH COMPLETE ***********" 
+  echo "JFD FETCH COMPLETE ***********" 
+  echo "JFD FETCH COMPLETE ***********" 
+  echo "JFD FETCH COMPLETE ***********" 
+  echo "JFD FETCH COMPLETE ***********" 
+  echo "JFD FETCH COMPLETE ***********" 
 
   # change dirs to v8
   cd v8
@@ -175,37 +185,112 @@ zopen_build() {
   # If proceed manually, this fails
   # cipd ensure depot_tools-main/.cipd_client is missing.
   # depot_tools-main is an old path, it no longer has a -main suffix
+  #
+  echo "JFD TODO: Do we do the DEPS.sed script here in patches?"
+  echo "JFD TODO: Do we do the DEPS.sed script here in patches?"
+  echo "JFD TODO: Do we do the DEPS.sed script here in patches?"
   gclient sync -D -v
 
 
   #
   # apply patches
   #
+  echo "JFD ABOUT TO APPLY PATCHES ***********" 
+  echo "JFD ABOUT TO APPLY PATCHES ***********" 
+  echo "JFD ABOUT TO APPLY PATCHES ***********" 
+  echo "JFD ABOUT TO APPLY PATCHES ***********" 
+  echo "JFD ABOUT TO APPLY PATCHES ***********" 
+  echo "JFD ABOUT TO APPLY PATCHES ***********" 
   git stash
-  for df in `find ${ZOPEN_ROOT}/patches/ -type f -name "git.*diff" | sort`; do
-    dirfile=`echo $df | sed "s:^${ZOPEN_ROOT}/patches/::"`
-    srcdir=`dirname $dirfile` 
-    echo "under $(pwd): srcdir=${srcdir}"
-    [[ "$srcdir" != "." ]] && pushd $srcdir && git stash
-    echo "git apply $MAINDIR/$df from `pwd`"
-    git apply $MAINDIR/$df
-    [[ "$srcdir" != "." ]] && popd
-  done
+
+  echo "Apply patches for overall repo"
+  echo "Apply patches for overall repo"
+  echo "Apply patches for overall repo"
+  cd ${ZOPEN_ROOT}/v8base/v8
+  echo "  -- compbuild"
+  git apply ${ZOPEN_ROOT}/patches/git.v8.compbuild.diff
+  echo "  -- cpp"
+  git apply ${ZOPEN_ROOT}/patches/git.v8.cpp.diff
+  echo "  -- debug"
+  git apply ${ZOPEN_ROOT}/patches/git.v8.debug.diff
+  echo "  -- v8"
+  git apply ${ZOPEN_ROOT}/patches/git.v8.diff
+  echo "  -- flags"
+  git apply ${ZOPEN_ROOT}/patches/git.v8.flags.diff
+  echo "  -- killharder"
+  git apply ${ZOPEN_ROOT}/patches/git.v8.killharder.diff
+  echo "  -- memset0"
+  git apply ${ZOPEN_ROOT}/patches/git.v8.memset0.diff
+  echo "  -- teststatus"
+  git apply ${ZOPEN_ROOT}/patches/git.v8.teststatus.diff
+  echo "  -- tls"
+  git apply ${ZOPEN_ROOT}/patches/git.v8.tls.diff
+  echo "Apply patch for third_party repos"
+  cd ${ZOPEN_ROOT}/v8base/v8/third_party
+  echo "  -- abseill-cpp"
+  cd ${ZOPEN_ROOT}/v8base/v8/third_party/abseil-cpp
+  git apply ${ZOPEN_ROOT}/patches/third_party/abseil-cpp/git.diff
+  echo "  -- fuzztest"
+  cd ${ZOPEN_ROOT}/v8base/v8/third_party/fuzztest/src
+  git apply ${ZOPEN_ROOT}/patches/third_party/fuzztest/src/git.diff
+  echo "  -- googletest"
+  cd ${ZOPEN_ROOT}/v8base/v8/third_party/googletest/src
+  git apply ${ZOPEN_ROOT}/patches/third_party/googletest/src/git.diff
+  echo "  -- protobuf_chrome"
+  cd ${ZOPEN_ROOT}/v8base/v8/third_party/protobuf_chrome
+  git apply ${ZOPEN_ROOT}/patches/third_party/protobuf_chrome/git.diff
+  echo "  -- re2"
+  cd ${ZOPEN_ROOT}/v8base/v8/third_party/re2/src
+  git apply ${ZOPEN_ROOT}/patches/third_party/re2/src/git.diff
+  echo "  -- zlib"
+  cd ${ZOPEN_ROOT}/v8base/v8/third_party/zlib
+  git apply ${ZOPEN_ROOT}/patches/third_party/zlib/git.diff
+  echo "Apply patches for overall repo complete"
+  echo "Apply patches for overall repo complete"
+  echo "Apply patches for overall repo complete"
+
+  echo "Perform file overlays"
+  echo "Perform file overlays"
+  echo "Perform file overlays"
+  cd ${ZOPEN_ROOT}/v8base/v8/
+  echo "nothing done. clarify.  TODO"
+  echo "  -- patches/buildtools/zos/ar"
+  echo "  -- patches/src/base/debug/stack_trace_zos.cc"
+  echo "  -- patches/src/base/platform/platform-zos.cc"
+  echo "  -- patches/src/heap/src/asm/zos/push_registers_asm.cc"
+  echo "  -- patches/src/snapshot/embedded/platform-embedded-file-writer-zos.cc"
+  echo "  -- patches/src/snapshot/embedded/platform-embedded-file-writer-zos.h"
+  echo "Perform file overlays complete"
+  echo "Perform file overlays complete"
+  echo "Perform file overlays complete"
 
   echo "Apply pax files to buildtools"
-  pushd buildtools
+  echo "Apply pax files to buildtools"
+  echo "Apply pax files to buildtools"
+  cd ${ZOPEN_ROOT}/v8base/v8/buildtools
   pax -p p -rzf ${ZOPEN_ROOT}/patches/buildtools/buildtools.zos.20231122.92b79f4d75.pax
-  popd
+  echo "Apply pax files to buildtools complete"
+  echo "Apply pax files to buildtools complete"
+  echo "Apply pax files to buildtools complete"
+
+  echo "JFD APPLY PATCHES COMPLETE ***********" 
+  echo "JFD APPLY PATCHES COMPLETE ***********" 
+  echo "JFD APPLY PATCHES COMPLETE ***********" 
+  echo "JFD APPLY PATCHES COMPLETE ***********" 
+  echo "JFD APPLY PATCHES COMPLETE ***********" 
+  echo "JFD APPLY PATCHES COMPLETE ***********" 
+
+
   #
   # Prepare v8 for building
   #
-  pushd buildtools/zos
+  cd ${ZOPEN_ROOT}/v8base/v8/buildtools/zos
   echo "change dir to v8base/v8/buildtools/zos level..."
   echo "make link to gn in v8base/v8/buildtools/zos"
   echo "using GN_HOME: ${GN_HOME}"
   echo "cwd: `pwd`"
   ln -s "${GN_HOME}/gn" .
-  popd
+  cd ../..
   export PATH="${PWD}:${ZOPEN_ROOT}/v8base/v8/buildtools/zos:$PATH" # for the 'ar' wrapper
   echo "ZOPEN_ROOT : ${ZOPEN_ROOT}"
   echo "PATH : ${PATH}"
@@ -213,11 +298,17 @@ zopen_build() {
   #echo "JFD EARLY EXIT"
   #exit
 
+
+
   #
   # Do the v8 build
   #
   echo "Generate ninja files using gn..."
   gn -v gen out/zos_s390x.release --args="is_debug=false treat_warnings_as_errors=false ${COMPONENT_BUILD}"
+  # Why was this done later?  Should we not do it now once the build output dir is there 
+  # and when the build happens?
+  # This is required when the built binaries (e.g. mksnapshot) and tests are run
+  export LIBPATH=${ZOPEN_ROOT}/out/zos_s390x.release:$LIBPATH
   echo "Perform build using ninja..."
   V=1 ninja -v -j ${ZOPEN_NUM_JOBS} -C out/zos_s390x.release/
 

--- a/buildenv
+++ b/buildenv
@@ -9,7 +9,7 @@
 # Use zopen build -vv to see if the dependencies are being processed
 export ZOPEN_TYPE="BARE"
 export ZOPEN_NAME="v8"
-export ZOPEN_DEPS="depot_tools zoslib cmake make python gn ninja git comp_clang"
+export ZOPEN_DEPS="depot_tools zoslib cmake make python gn ninja git comp_clang bash"
 
 export ZOPEN_RUNTIME_DEPS="zoslib python"
 # Nothing to configure or build:?

--- a/buildenv
+++ b/buildenv
@@ -9,7 +9,7 @@
 # Use zopen build -vv to see if the dependencies are being processed
 export ZOPEN_TYPE="BARE"
 export ZOPEN_NAME="v8"
-export ZOPEN_DEPS="depot_tools zoslib cmake make check_python gn ninja git check_clang bas bash"
+export ZOPEN_DEPS="depot_tools zoslib cmake make check_python gn ninja git check_clang"
 
 export ZOPEN_RUNTIME_DEPS="zoslib check_python"
 # Nothing to configure or build:?

--- a/cicd-dev.groovy
+++ b/cicd-dev.groovy
@@ -9,6 +9,6 @@ node('linux')
       userRemoteConfigs: [[url: 'https://github.com/zopencommunity/v8port.git']]])
   }
   stage('Build') {
-    build job: 'Port-Pipeline', parameters: [string(name: 'PORT_GITHUB_REPO', value: 'https://github.com/zopencommunity/v8port.git'), string(name: 'PORT_DESCRIPTION', value: 'A port of Google V8 JavaScript engine to z/OS Open Tools project' ), string(name: 'BUILD_LINE', value: 'DEV') ]
+    build job: 'Port-Pipeline', parameters: [string(name: 'PORT_GITHUB_REPO', value: 'https://github.com/zopencommunity/v8port.git'), string(name: 'PORT_DESCRIPTION', value: 'A port of Google V8 JavaScript engine to z/OS Open Tools project' ), string(name: 'BUILD_LINE', value: 'DEV'), string(name: 'NODE_LABEL', value: "v3r1" ) ]
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 httplib2
 # six is definitely used
-#six
+six
 setuptools
 # this also has a six implementation
 # I've seen some fixes on internet which referenced using this lib

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
 
-export DEPOT_TOOLS_HOME=${HOME}/zopen/usr/local/zopen/depot_tools/depot_tools/
-
 export PATH="${HOME}/zopen/usr/local/bin:${DEPOT_TOOLS_HOME}:${GN_HOME}:$PATH"
 
 # update the compiler settings
@@ -50,5 +48,6 @@ gclient metrics --opt-out
 
 echo "Change to v8base/v8 and run ninja"
 echo "  eg: v8base/v8"
+echo "      gn gen -v -c out/zos_s390x.release"
 echo "      ninja -v -C out/zos_s390x.release"
 

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,91 +1,54 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-# The path and environment variables are updated as a result of the package install.
-# However, if the user installs the package and does not run the zopen-config
-# command in the current shell, then the path will not be there yet.  In 
-# this case check for the path in the current path.
 
-desired_path="zopen/usr/local/zopen/depot_tools/depot_tools-main"
+export DEPOT_TOOLS_HOME=${HOME}/zopen/usr/local/zopen/depot_tools/depot_tools/
 
-if  expr "${PATH}" : ".*${desired_path}.*" 1>/dev/null ; then
-    echo "Good. depot_tools is in path."
-else
-    echo "Path to depot_tools missing.  Adding it to path.."
-    export PATH=${PATH}:${HOME}/${desired_path}
+export PATH="${HOME}/zopen/usr/local/bin:${DEPOT_TOOLS_HOME}:${GN_HOME}:$PATH"
+
+# update the compiler settings
+unset CFLAGS CXXFLAGS LDFLAGS
+
+export DEPOT_TOOLS_UPDATE=0
+# do the export and the set
+export CUSTOM_CIPD_CLIENT=${DEPOT_TOOLS_HOME}/.cipd_client
+export DEPOT_TOOLS_BOOTSTRAP_PYTHON3=0
+export VPYTHON_BYPASS='manually managed python not supported by chrome operations'
+
+if [ -d "venv" ]; then
+    # virtual env exists, no need to create
+    echo "venv exists"
+else 
+    # Create the virtual env in the v8port install dir
+    echo "    Creating a python venv..."
+    python3 -m venv venv
 fi
 
-
-# activate the virtual env
+# depot_tools creates the venv, here we ensure the necessary packages are installed
+# Activate the path
 echo "activating the virtual env - venv"
-. ${HOME}/zopen/usr/local/zopen/v8/v8-DEV/venv/bin/activate
+. venv/bin/activate
 
-# update the virtual env
+# Update the virtual env
+echo "updating the virtual env pip"
 python -m pip install -U pip
 
 
-# install the necessary requirements
-echo "Installing packages via requirements.txt..."
-pip install -r ${HOME}/zopen/usr/local/zopen/v8/v8-DEV/requirements.txt
+# Install the necessary requirements
+if [ -d "venv" ]; then
+    # virtual env exists, no need to install libs
+    echo "venv exists"
+else 
+    # Install the necessary libs
+    echo "Installing reqired package in venv"
+    pip install -r requirements.txt
+fi
 
-# Using depot_tools disable metrics.
+
+echo "Invoking gclient metrics --opt-out"
 # Comment out this line if you wish to participate.
 gclient metrics --opt-out
 
-
-# provide a mechanism to resume work on v8 versus 
-# ensure pristine.   Assume by default the user
-# desires a pristine state and a fresh fetch.
-RESUME=0
-while [ $# -gt 0 ]; do
-    case "$1" in
-        -resume)
-            echo "-resume switch used.  Skipping .gclient* delete"
-            RESUME=1
-            shift
-            ;;
-        -optionx)
-            echo "option x used with value $2"
-            echo "TODO: nothing to do yet"
-            shift 2
-            ;;
-        *)
-            echo "unknown option"
-            echo "USAGE: $0 [-resume]"
-            exit 1
-            ;;
-    esac
-done
-
-# remove any previous attempts of fetch
-# so as to pull a fresh copy.  If this is the first time building
-# depot tools, these file will not be present and thus
-# no need to attempt to remove them. 
-# NOTE: assuming v8 will be built in $HOME/zopen/dev/v8port/v8base
-if [ ${RESUME} -eq 0 ]; then
-    echo "Attempting to delete any leftover .gclient* entries"
-    if [ -d "${HOME}/zopen/dev/v8port/v8base" ]; then
-        if [ -f "${HOME}/zopen/dev/v8port/v8base/.gclient_entries" ]; then
-            rm ${HOME}/zopen/dev/v8port/v8base/.gclient_entries
-        fi
-        if [ -f "${HOME}/zopen/dev/v8port/v8base/.gclient" ]; then
-            rm ${HOME}/zopen/dev/v8port/v8base/.gclient
-        fi
-    fi
-fi
-
-
-# start ssh-agent
-if ps -A | grep ssh-agent; then
-    echo "ssh-agent is already running"
-    echo "connecting to existing now..."
-    AGENT_SCRIPT=$(ssh-agent -s)
-    # Now run this script in current shell
-    eval "${AGENT_SCRIPT}"
-
-else
-    echo "ssh-agent is not running"
-    echo "starting now..."
-    eval `ssh-agent`
-fi
-
+echo "Change to v8base/v8 and run ninja"
+echo "  eg: v8base/v8"
+echo "      ninja -v -C out/zos_s390x.release"
 


### PR DESCRIPTION
This is the build I've been running and using.  Its a component build that builds .so instead of static builds.  With that said there are a couple of things to address:

* What should we do regarding the overlay files?  There are files in the patches directory, see the buildenv where they could be used.  Currently they are identified as TODO.  One is a sed script and the others are source files.
* The component build will fail with a coredump in out/zos.s390x which shows libuuic.so is missing.  I'm attempting to build with ZOPEN_NUM_JOBS=1 to see if its a multithreading issue.  Regardless, when it fails, afterwards the ninja build will complete without error.